### PR TITLE
Add update-stats workflow

### DIFF
--- a/.github/workflows/update-stats.yaml
+++ b/.github/workflows/update-stats.yaml
@@ -1,0 +1,57 @@
+name: Update stats
+
+on:
+  schedule:
+    - cron: "0 6 1,15 * *" # At 06:00 on day-of-month 1 and 15
+  workflow_dispatch:
+    inputs:
+      target_branch:
+        required: true
+        default: stats
+        type: string
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.target_branch || 'stats' }}
+
+      - name: Git Config
+        run: |
+          git config core.fileMode false
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        shell: bash
+
+      - name: Update top-langs (light)
+        uses: readme-tools/github-readme-stats-action@v1
+        with:
+          card: top-langs
+          options: username=${{ github.repository_owner }}&layout=compact&hide=java
+          path: top-langs-light.svg
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update top-langs (dark)
+        uses: readme-tools/github-readme-stats-action@v1
+        with:
+          card: top-langs
+          options: username=${{ github.repository_owner }}&layout=compact&hide=java&theme=github_dark_dimmed
+          path: top-langs-dark.svg
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Git Commit
+        run: |
+          git status -s
+          git add .
+          git diff --cached --quiet --exit-code
+          if [ $? -eq 0 ]; then echo "No git changes"; exit 0; fi
+
+          git commit -m "Update stats"
+          git push
+        shell: bash {0}

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@
 #### Language Stats
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://github-readme-stats.vercel.app/api/top-langs/?username=jurakovic&layout=compact&hide=java&theme=github_dark_dimmed">
-  <source media="(prefers-color-scheme: light)" srcset="https://github-readme-stats.vercel.app/api/top-langs/?username=jurakovic&layout=compact&hide=java">
-  <img src="https://github-readme-stats.vercel.app/api/top-langs/?username=jurakovic&layout=compact&hide=java&theme=github_dark_dimmed">
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jurakovic/jurakovic/refs/heads/stats/top-langs-dark.svg">
+  <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/jurakovic/jurakovic/refs/heads/stats/top-langs-light.svg">
+  <img src="https://raw.githubusercontent.com/jurakovic/jurakovic/refs/heads/stats/top-langs-dark.svg">
 </picture>

--- a/build.sh
+++ b/build.sh
@@ -100,9 +100,9 @@ cat << EOF >> $readme
 #### Language Stats
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://github-readme-stats.vercel.app/api/top-langs/?username=jurakovic&layout=compact&hide=java&theme=github_dark_dimmed">
-  <source media="(prefers-color-scheme: light)" srcset="https://github-readme-stats.vercel.app/api/top-langs/?username=jurakovic&layout=compact&hide=java">
-  <img src="https://github-readme-stats.vercel.app/api/top-langs/?username=jurakovic&layout=compact&hide=java&theme=github_dark_dimmed">
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jurakovic/jurakovic/refs/heads/stats/top-langs-dark.svg">
+  <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/jurakovic/jurakovic/refs/heads/stats/top-langs-light.svg">
+  <img src="https://raw.githubusercontent.com/jurakovic/jurakovic/refs/heads/stats/top-langs-dark.svg">
 </picture>
 EOF
 


### PR DESCRIPTION
> _As we are no longer sponsored by Vercel (see [this April 2024 message](https://github.com/anuraghazra/github-readme-stats/issues/3851#issuecomment-2237316047)), we can no longer reliably operate the public instance at its current scale. The public endpoint remains available, but users should expect downtime._
> 
> _To provide a stable alternative, we have released a new [GitHub Action](https://github.com/marketplace/actions/github-readme-stats-action), which is now the recommended way to use the project. This approach is significantly more stable and allows for [more accurate tracking](https://github.com/readme-tools/github-readme-stats-action) as improvements are introduced._
> 
> _Alternatively, you can deploy the project on your [own instance](https://github.com/anuraghazra/github-readme-stats?tab=readme-ov-file#deploy-on-your-own), which has been the recommended setup for years and supports private data._

Source: [anuraghazra/github-readme-stats #3851](https://github.com/anuraghazra/github-readme-stats/issues/3851#issuecomment-3693883854)

---

[Update stats](https://github.com/jurakovic/jurakovic/blob/master/.github/workflows/update-stats.yaml) workflow that uses [GitHub Readme Stats](https://github.com/marketplace/actions/github-readme-stats-action) action was created.

[stats](https://github.com/jurakovic/jurakovic/tree/stats) branch was created to store stats data and it was created as an orphaned branch to keep stats history separated from master branch history.
